### PR TITLE
Allow "All devices" access for controller support

### DIFF
--- a/org.yamagi.YamagiQ2.yaml
+++ b/org.yamagi.YamagiQ2.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=dri
+  - --device=all
   - --share=ipc
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
Gives the device access required for controller support to work in the Flatpak.